### PR TITLE
Add encodeLE/decodeLE, fixing #19

### DIFF
--- a/System/OsString.hs
+++ b/System/OsString.hs
@@ -24,6 +24,7 @@ module System.OsString
   , unsafeEncodeUtf
   , encodeWith
   , encodeFS
+  , encodeLE
   , osstr
   , empty
   , singleton
@@ -33,6 +34,7 @@ module System.OsString
   , decodeUtf
   , decodeWith
   , decodeFS
+  , decodeLE
   , unpack
 
   -- * Word types
@@ -136,14 +138,14 @@ import System.OsString.Internal
     , encodeUtf
     , unsafeEncodeUtf
     , encodeWith
-    , encodeFS
+    , encodeLE
     , osstr
     , pack
     , empty
     , singleton
     , decodeUtf
     , decodeWith
-    , decodeFS
+    , decodeLE
     , unpack
     , snoc
     , cons
@@ -206,6 +208,38 @@ import System.OsString.Internal
     , findIndex
     , findIndices
     )
+import qualified System.OsString.Internal as SOI
 import System.OsString.Internal.Types
     ( OsString, OsChar, coercionToPlatformTypes )
-import Prelude ()
+import Prelude (String, IO)
+
+{-# DEPRECATED encodeFS "Use System.OsPath.encodeFS from filepath" #-}
+-- | Like 'encodeUtf', except this mimics the behavior of the base library when doing filesystem
+-- operations (usually filepaths), which is:
+--
+-- 1. on unix, uses shady PEP 383 style encoding (based on the current locale,
+--    but PEP 383 only works properly on UTF-8 encodings, so good luck)
+-- 2. on windows does permissive UTF-16 encoding, where coding errors generate
+--    Chars in the surrogate range
+--
+-- Looking up the locale requires IO. If you're not worried about calls
+-- to 'setFileSystemEncoding', then 'unsafePerformIO' may be feasible (make sure
+-- to deeply evaluate the result to catch exceptions).
+encodeFS :: String -> IO OsString
+encodeFS = SOI.encodeFS
+
+{-# DEPRECATED decodeFS "Use System.OsPath.encodeFS from filepath" #-}
+-- | Like 'decodeUtf', except this mimics the behavior of the base library when doing filesystem
+-- operations (usually filepaths), which is:
+--
+-- 1. on unix, uses shady PEP 383 style encoding (based on the current locale,
+--    but PEP 383 only works properly on UTF-8 encodings, so good luck)
+-- 2. on windows does permissive UTF-16 encoding, where coding errors generate
+--    Chars in the surrogate range
+--
+-- Looking up the locale requires IO. If you're not worried about calls
+-- to 'setFileSystemEncoding', then 'unsafePerformIO' may be feasible (make sure
+-- to deeply evaluate the result to catch exceptions).
+decodeFS :: OsString -> IO String
+decodeFS = SOI.decodeFS
+

--- a/System/OsString/Encoding.hs
+++ b/System/OsString/Encoding.hs
@@ -23,6 +23,8 @@ module System.OsString.Encoding
   -- * base encoding
   , encodeWithBasePosix
   , decodeWithBasePosix
+  , encodeWithBasePosix'
+  , decodeWithBasePosix'
   , encodeWithBaseWindows
   , decodeWithBaseWindows
   )

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`os-string` package](http://hackage.haskell.org/package/os-string)
 
+## 2.0.5 *Jun 2024*
+
+* Add `decodeLE`/`encodeLE` and deprecate `decodeFS`/`encodeFS` (pointing users to `System.OsPath` instead), fixes [#19](https://github.com/haskell/os-string/issues/19)
+
 ## 2.0.3 *May 2024*
 
 * Fix `length` function wrt [#17](https://github.com/haskell/os-string/issues/17)

--- a/os-string.cabal
+++ b/os-string.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               os-string
-version:            2.0.3
+version:            2.0.5
 
 -- NOTE: Don't forget to update ./changelog.md
 license:            BSD-3-Clause


### PR DESCRIPTION
TODO:

- [x] ~~make sure `filepath` uses the internal API to avoid deprecation warnings getting triggered~~ (https://github.com/haskell/filepath/pull/232)
