### PR TITLE
Add safe conversions from ShortByteString

### DIFF
--- a/System/OsString/Common.hs
+++ b/System/OsString/Common.hs
@@ -38,8 +38,10 @@ module System.OsString.MODULE_NAME
   , fromString
 #endif
   , fromBytes
+  , fromShortBytes
 #ifndef WINDOWS
   , fromBytestring
+  , fromShortBytestring
 #endif
   , pstr
   , singleton
@@ -158,6 +160,8 @@ import Control.Monad.Catch
     ( MonadThrow, throwM )
 import Data.ByteString.Internal
     ( ByteString )
+import Data.ByteString.Short.Internal
+    ( ShortByteString )
 import Control.Exception
     ( SomeException, try, displayException )
 import Control.DeepSeq ( force )
@@ -426,6 +430,33 @@ fromBytes bs =
 fromBytes = pure . PosixString . BSP.toShort
 #endif
 
+#ifdef WINDOWS_DOC
+-- | Constructs a platform string from a ShortByteString.
+--
+-- This ensures valid UCS-2LE.
+-- Note that this doesn't expand Word8 to Word16 on windows, so you may get invalid UTF-16.
+--
+-- Throws 'EncodingException' on invalid UCS-2LE (although unlikely).
+--
+-- @since 2.0.8
+#else
+-- | Constructs a platform string from a ShortByteString.
+--
+-- This is a no-op.
+--
+-- @since 2.0.8
+#endif
+fromShortBytes :: MonadThrow m
+               => ShortByteString
+               -> m PLATFORM_STRING
+#ifdef WINDOWS
+fromShortBytes bs =
+  let ws = WindowsString bs
+  in either throwM (const . pure $ ws) $ decodeWith ucs2le ws
+#else
+fromShortBytes = pure . PosixString
+#endif
+
 #ifndef WINDOWS
 -- | Like 'fromBytes', but not in IO.
 --
@@ -438,6 +469,12 @@ fromBytes = pure . PosixString . BSP.toShort
 -- @since 2.0.6
 fromBytestring :: ByteString -> PosixString
 fromBytestring = PosixString . BSP.toShort
+
+-- | Like 'fromShortBytes', but not in IO, similarly to 'fromBytestring'
+--
+-- @since 2.0.8
+fromShortBytestring :: ShortByteString -> PosixString
+fromShortBytestring = PosixString
 #endif
 
 

--- a/System/OsString/Internal.hs
+++ b/System/OsString/Internal.hs
@@ -14,6 +14,8 @@ import Control.Monad.Catch
     ( MonadThrow )
 import Data.ByteString
     ( ByteString )
+import Data.ByteString.Short
+    ( ShortByteString )
 import Data.Char
 import Language.Haskell.TH.Quote
     ( QuasiQuoter (..) )
@@ -169,6 +171,16 @@ fromBytes :: MonadThrow m
           => ByteString
           -> m OsString
 fromBytes = fmap OsString . PF.fromBytes
+
+-- | Constructs an @OsString@ from a ShortByteString.
+--
+-- On windows, this ensures valid UCS-2LE, on unix it is passed unchanged/unchecked.
+--
+-- Throws 'EncodingException' on invalid UCS-2LE on windows (although unlikely).
+fromShortBytes :: MonadThrow m
+               => ShortByteString
+               -> m OsString
+fromShortBytes = fmap OsString . PF.fromShortBytes
 
 
 -- | QuasiQuote an 'OsString'. This accepts Unicode characters


### PR DESCRIPTION
OsString is internally represented as a ShortByteString, however safe conversion functions `fromBytes` and `fromBytestring` were only present for ByteStrings; when dealing with ShortByteStrings directly this would require a useless conversion to a bytestring first.

This PR adds the `fromShortBytes` and `fromShortBytestring` functions which create an OsString from ShortByteString, possibly throwing an error on incorrect encoding