### PR TITLE
Switch from template-haskell to template-haskell-lift and -quasiquoter

### DIFF
--- a/System/OsString/Common.hs
+++ b/System/OsString/Common.hs
@@ -169,10 +169,17 @@ import Data.Bifunctor ( first )
 import GHC.IO
     ( evaluate, unsafePerformIO )
 import qualified GHC.Foreign as GHC
+#if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift
+    (Lift(..))
+import Language.Haskell.TH.QuasiQuoter
+    ( QuasiQuoter (..) )
+#else
+import Language.Haskell.TH.Syntax
+    (Lift(..))
 import Language.Haskell.TH.Quote
     ( QuasiQuoter (..) )
-import Language.Haskell.TH.Syntax
-    ( Lift (..), lift )
+#endif
 
 
 import GHC.IO.Encoding.Failure ( CodingFailureMode(..) )

--- a/System/OsString/Internal.hs
+++ b/System/OsString/Internal.hs
@@ -17,10 +17,17 @@ import Data.ByteString
 import Data.ByteString.Short
     ( ShortByteString )
 import Data.Char
+#if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift
+    (Lift(..), lift)
+import Language.Haskell.TH.QuasiQuoter
+    ( QuasiQuoter (..) )
+#else
+import Language.Haskell.TH.Syntax
+    (Lift(..), lift)
 import Language.Haskell.TH.Quote
     ( QuasiQuoter (..) )
-import Language.Haskell.TH.Syntax
-    ( Lift (..), lift )
+#endif
 import System.IO
     ( TextEncoding )
 

--- a/System/OsString/Internal/Types.hs
+++ b/System/OsString/Internal/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
@@ -36,8 +37,11 @@ import Data.Coerce (coerce)
 import Data.Data
 import Data.Type.Coercion (Coercion(..), coerceWith)
 import Data.Word
-import Language.Haskell.TH.Syntax
-    ( Lift (..), lift )
+#if __GLASGOW_HASKELL__ >= 914
+import Language.Haskell.TH.Lift (Lift)
+#else
+import Language.Haskell.TH.Syntax (Lift)
+#endif
 #if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup
 #endif
@@ -46,7 +50,6 @@ import GHC.Generics (Generic)
 import System.OsString.Encoding.Internal
 import qualified System.OsString.Data.ByteString.Short as BS
 import qualified System.OsString.Data.ByteString.Short.Word16 as BS16
-import qualified Language.Haskell.TH.Syntax as TH
 
 -- Using unpinned bytearrays to avoid Heap fragmentation and
 -- which are reasonably cheap to pass to FFI calls
@@ -58,7 +61,7 @@ import qualified Language.Haskell.TH.Syntax as TH
 
 -- | Commonly used windows string as wide character bytes.
 newtype WindowsString = WindowsString { getWindowsString :: BS.ShortByteString }
-  deriving (Eq, Ord, Semigroup, Monoid, Typeable, Generic, NFData)
+  deriving (Eq, Ord, Semigroup, Monoid, Typeable, Generic, NFData, Lift)
 
 -- | Decodes as UCS-2.
 instance Show WindowsString where
@@ -73,19 +76,10 @@ pattern WS { unWS } <- WindowsString unWS where
 {-# COMPLETE WS #-}
 #endif
 
-
-instance Lift WindowsString where
-  lift (WindowsString bs) = TH.AppE (TH.ConE 'WindowsString) <$> (lift bs)
-#if MIN_VERSION_template_haskell(2,17,0)
-  liftTyped = TH.unsafeCodeCoerce . TH.lift
-#elif MIN_VERSION_template_haskell(2,16,0)
-  liftTyped = TH.unsafeTExpCoerce . TH.lift
-#endif
-
 -- | Commonly used Posix string as uninterpreted @char[]@
 -- array.
 newtype PosixString = PosixString { getPosixString :: BS.ShortByteString }
-  deriving (Eq, Ord, Semigroup, Monoid, Typeable, Generic, NFData)
+  deriving (Eq, Ord, Semigroup, Monoid, Typeable, Generic, NFData, Lift)
 
 -- | Prints the raw bytes without decoding.
 instance Show PosixString where
@@ -97,14 +91,6 @@ pattern PS { unPS } <- PosixString unPS where
   PS a = PosixString a
 #if __GLASGOW_HASKELL__ >= 802
 {-# COMPLETE PS #-}
-#endif
-
-instance Lift PosixString where
-  lift (PosixString bs) = TH.AppE (TH.ConE 'PosixString) <$> (lift bs)
-#if MIN_VERSION_template_haskell(2,17,0)
-  liftTyped = TH.unsafeCodeCoerce . TH.lift
-#elif MIN_VERSION_template_haskell(2,16,0)
-  liftTyped = TH.unsafeTExpCoerce . TH.lift
 #endif
 
 
@@ -159,7 +145,7 @@ type PlatformChar = PosixChar
 -- dealing with the internals isn't generally recommended, but supported
 -- in case you need to write platform specific code.
 newtype OsString = OsString { getOsString :: PlatformString }
-  deriving (Typeable, Generic, NFData)
+  deriving (Typeable, Generic, NFData, Lift)
 
 -- | On windows, decodes as UCS-2. On unix prints the raw bytes without decoding.
 instance Show OsString where
@@ -188,20 +174,6 @@ instance Monoid OsString where
 instance Semigroup OsString where
     (<>) = coerce (mappend :: BS.ShortByteString -> BS.ShortByteString -> BS.ShortByteString)
 #endif
-
-
-instance Lift OsString where
-  lift xs = case coercionToPlatformTypes of
-    Left (_, co) ->
-      TH.AppE (TH.ConE 'OsString) <$> (lift $ coerceWith co xs)
-    Right (_, co) -> do
-      TH.AppE (TH.ConE 'OsString) <$> (lift $ coerceWith co xs)
-#if MIN_VERSION_template_haskell(2,17,0)
-  liftTyped = TH.unsafeCodeCoerce . TH.lift
-#elif MIN_VERSION_template_haskell(2,16,0)
-  liftTyped = TH.unsafeTExpCoerce . TH.lift
-#endif
-
 
 -- | Newtype representing a code unit.
 --

--- a/os-string.cabal
+++ b/os-string.cabal
@@ -68,7 +68,15 @@ library
     , bytestring        >=0.11.3.0
     , deepseq
     , exceptions
-    , template-haskell
+  -- template-haskell-lift was added as a boot library in GHC-9.14
+  -- once we no longer wish to backport releases to older major releases of GHC,
+  -- this conditional can be dropped
+  if impl(ghc < 9.14)
+      build-depends: template-haskell
+  elif impl(ghc)
+      build-depends:
+        , template-haskell-lift >=0.1 && <0.2
+        , template-haskell-quasiquoter >=0.1 && <0.2
 
   ghc-options:      -Wall
 


### PR DESCRIPTION
We switch our dependency on template-haskell to a dependency on template-haskell-lift. This smaller library is more stabler and if we can remove the template-haskell dependency from all boot libraries then template-haskell will be much easier to re-install since it no longer needs to be in GHC's dependency closure.

For more information see the GHC proposal that introduced this library: https://github.com/ghc-proposals/ghc-proposals/pull/696

This GHC MR tests this PR against GHC-HEAD: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/14978