### PR TITLE
Fix markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # OsString [![Hackage version](https://img.shields.io/hackage/v/os-string.svg?label=Hackage)](https://hackage.haskell.org/package/os-string)
 
-This package provides functionality for manipulating @OsString@ values, and is shipped with <https://www.haskell.org/ghc/ GHC>.
-
+This package provides functionality for manipulating `OsString` values, and is shipped with [GHC](https://www.haskell.org/ghc/).


### PR DESCRIPTION
Hackage renders README.md as markdown, not using Haddock syntax.